### PR TITLE
Reset logging config on teardown

### DIFF
--- a/pytest_structlog.py
+++ b/pytest_structlog.py
@@ -57,8 +57,16 @@ def no_op(*args, **kwargs):
 
 @pytest.fixture
 def log(monkeypatch):
+    # save settings for later
+    processors = structlog.get_config().get('processors', [])
+    configure = structlog.configure
+
+    # redirect logging to log capture
     cap = StructuredLogCapture()
     structlog.configure(processors=[cap.process])
     monkeypatch.setattr("structlog.configure", no_op)
     monkeypatch.setattr("structlog.configure_once", no_op)
-    return cap
+    yield cap
+
+    # back to normal behavior
+    configure(processors=processors)


### PR DESCRIPTION
The `log` fixture should not have any side effects on other tests. Now
it only changes the log handling during the test instead of keeping the
change for all following tests.