### PR TITLE
Add __repr__() to StructuredLogCapture class.

### DIFF
--- a/pytest_structlog.py
+++ b/pytest_structlog.py
@@ -53,6 +53,9 @@ class StructuredLogCapture(object):
         context["event"] = message
         return any(is_submap(context, e) for e in self.events)
 
+    def __repr__(self):
+        return "<StructuredLogCapture with %r>" % (self.events)
+
 
 def no_op(*args, **kwargs):
     pass

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -140,3 +140,8 @@ def test_dupes(log):
         {"event": "a", "level": "info"},
         {"event": "b", "level": "info"},
     ]
+
+def test_structuredlogcapture_returns_correct_representation(log):
+    logger.info("a")
+
+    assert repr(log) == "<StructuredLogCapture with [{'event': 'a', 'level': 'info'}]>"


### PR DESCRIPTION
This is to print the content of the captured log events when the test fails. To my knowledge, there is no disadvantage related to this change.

When the test fails it prints the value of the fixture. When the fixture is an object the default representation is used:
```
======================================================================================================================================================================= test session starts ========================================================================================================================================================================
platform linux -- Python 3.9.2, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /foo
plugins: cov-2.11.1, structlog-0.3
collected 2 items                                                                                                                                                                                                                                                                                                                                                  

tests/integration/logging_test.py .F                                                                                                                                                                                                                                                                                                                         [100%]

============================================================================================================================================================================= FAILURES =============================================================================================================================================================================
___________________________________________________________________________________________________________________________________________________________________ test_logger_works_correctly ____________________________________________________________________________________________________________________________________________________________________

log = <pytest_structlog.StructuredLogCapture object at 0x7f5940e59e50>   <--- Notice this.

    def test_logger_works_correctly(log):
        hmil_log.error('a unique error message')
        hmil_log.warning('a unique warning message')
    
>       assert False
E       assert False

tests/integration/logging_test.py:32: AssertionError
```

This PR changes the output to:
```
======================================================================================================================================================================= test session starts ========================================================================================================================================================================
platform linux -- Python 3.9.2, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /foo
plugins: cov-2.11.1, structlog-0.3
collected 2 items                                                                                                                                                                                                                                                                                                                                                  

tests/integration/logging_test.py .F                                                                                                                                                                                                                                                                                                                         [100%]

============================================================================================================================================================================= FAILURES =============================================================================================================================================================================
___________________________________________________________________________________________________________________________________________________________________ test_logger_works_correctly ____________________________________________________________________________________________________________________________________________________________________

log = <StructuredLogCapture with [{'username': 'hmil', 'event': 'a unique error message', 'level': 'error'}, {'username': 'hmil', 'event': 'a unique warning message', 'level': 'warning'}]>

    def test_logger_works_correctly(log):
        hmil_log.error('a unique error message')
        hmil_log.warning('a unique warning message')
    
>       assert False
E       assert False

tests/integration/logging_test.py:29: AssertionError
```