### PR TITLE
v0.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="pytest-structlog",
-    version="0.3",
+    version="0.4",
     url="https://github.com/wimglenn/pytest-structlog",
     description="Structured logging assertions",
     long_description=open("README.rst").read(),


### PR DESCRIPTION
dump out events on test failures. no longer reset_defaults in setup, since it caused a regression in #14. users should mock out their own structlog configuration in tests if necessary