### PR TITLE
Add factory method for log events to assert on for better readability

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,15 @@ Then your test suite might use assertions such as shown below:
            {"event": "processing", "level": "debug", "spline": 2},
            {"event": "reticulated splines", "level": "info", "n_splines": 3},
        ]
+       
+       # can use friendly factory methods for the events to assert on
+       assert log.events == [
+           log.info("reticulating splines"},
+           log.debug("processing", spline=0},
+           log.debug("processing", spline=1},
+           log.debug("processing", spline=2},
+           log.info("reticulated splines", n_splines=3},
+       ]
 
        # can use membership to check for a single event's data
        assert {"event": "reticulating splines", "level": "info"} in log.events

--- a/README.rst
+++ b/README.rst
@@ -84,11 +84,11 @@ Then your test suite might use assertions such as shown below:
        
        # can use friendly factory methods for the events to assert on
        assert log.events == [
-           log.info("reticulating splines"},
-           log.debug("processing", spline=0},
-           log.debug("processing", spline=1},
-           log.debug("processing", spline=2},
-           log.info("reticulated splines", n_splines=3},
+           log.info("reticulating splines"),
+           log.debug("processing", spline=0),
+           log.debug("processing", spline=1),
+           log.debug("processing", spline=2),
+           log.info("reticulated splines", n_splines=3),
        ]
 
        # can use membership to check for a single event's data

--- a/pytest_structlog.py
+++ b/pytest_structlog.py
@@ -77,7 +77,9 @@ class StructuredLogCapture(object):
 
     def log(self, level, event, **kw):
         """Create log event to assert against"""
-        return {"level": level_to_name(level), "event": event, **kw}
+        result = {"level": level_to_name(level), "event": event}
+        result.update(kw)
+        return result
 
     def debug(self, event, **kw):
         """Create debug-level log event to assert against"""

--- a/pytest_structlog.py
+++ b/pytest_structlog.py
@@ -42,8 +42,7 @@ absent = object()
 
 
 def level_to_name(level):
-    """Given the name or number for a log-leve, return the
-    lower-case level name."""
+    """Given the name or number for a log-level, return the lower-case level name."""
     if isinstance(level, str):
         return level.lower()
     try:

--- a/pytest_structlog.py
+++ b/pytest_structlog.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 import pytest
@@ -40,6 +41,17 @@ class EventList(list):
 absent = object()
 
 
+def level_to_name(level):
+    """Given the name or number for a log-leve, return the
+    lower-case level name."""
+    if isinstance(level, str):
+        return level.lower()
+    try:
+        return logging._levelToName[level].lower()
+    except KeyError:
+        raise ValueError("Unknown level number " + str(level))
+
+
 def is_submap(d1, d2):
     """is every pair from d1 also in d2? (unique and order insensitive)"""
     return all(d2.get(k, absent) == v for k, v in d1.items())
@@ -63,6 +75,30 @@ class StructuredLogCapture(object):
     def has(self, message, **context):
         context["event"] = message
         return any(is_submap(context, e) for e in self.events)
+
+    def log(self, level, event, **kw):
+        """Create log event to assert against"""
+        return {"level": level_to_name(level), "event": event, **kw}
+
+    def debug(self, event, **kw):
+        """Create debug-level log event to assert against"""
+        return self.log(logging.DEBUG, event, **kw)
+
+    def info(self, event, **kw):
+        """Create info-level log event to assert against"""
+        return self.log(logging.INFO, event, **kw)
+
+    def warning(self, event, **kw):
+        """Create warning-level log event to assert against"""
+        return self.log(logging.WARNING, event, **kw)
+
+    def error(self, event, **kw):
+        """Create error-level log event to assert against"""
+        return self.log(logging.ERROR, event, **kw)
+
+    def critical(self, event, **kw):
+        """Create critical-level log event to assert against"""
+        return self.log(logging.CRITICAL, event, **kw)
 
 
 def no_op(*args, **kwargs):

--- a/pytest_structlog.py
+++ b/pytest_structlog.py
@@ -45,10 +45,7 @@ def level_to_name(level):
     """Given the name or number for a log-level, return the lower-case level name."""
     if isinstance(level, str):
         return level.lower()
-    try:
-        return logging.getLevelName(level).lower()
-    except KeyError:
-        raise ValueError("Unknown level number " + str(level))
+    return logging.getLevelName(level).lower()
 
 
 def is_submap(d1, d2):

--- a/pytest_structlog.py
+++ b/pytest_structlog.py
@@ -46,7 +46,7 @@ def level_to_name(level):
     if isinstance(level, str):
         return level.lower()
     try:
-        return logging._levelToName[level].lower()
+        return logging.getLevelName(level).lower()
     except KeyError:
         raise ValueError("Unknown level number " + str(level))
 
@@ -77,9 +77,7 @@ class StructuredLogCapture(object):
 
     def log(self, level, event, **kw):
         """Create log event to assert against"""
-        result = {"level": level_to_name(level), "event": event}
-        result.update(kw)
-        return result
+        return dict(level=level_to_name(level), event=event, **kw)
 
     def debug(self, event, **kw):
         """Create debug-level log event to assert against"""

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -171,7 +171,5 @@ def test_dynamic_event_factory(log, level, name):
     assert log.log(name.upper(), "dynamic-level", other=42) == expected
 
 
-def test_event_factory__bad_level(log):
-    with pytest.raises(ValueError) as exi:
-        log.log(1234, "text")
-    assert str(exi.value) == "Unknown level number 1234"
+def test_event_factory__bad_level_number(log):
+    assert log.log(1234, "text") == {'event': 'text', 'level': 'level 1234'}


### PR DESCRIPTION
I have made a number of additions to pytest-structlog locally and this is the lowest-hanging fruit of that to submit. It makes the lists of log events to assert on more terse and more readable.