### PR TITLE
Clear contextvars between tests

### DIFF
--- a/pytest_structlog.py
+++ b/pytest_structlog.py
@@ -1,13 +1,16 @@
 import os
+
 import pytest
 import structlog
 
 try:
     from structlog.contextvars import merge_contextvars
+    from structlog.contextvars import clear_contextvars
 except ImportError:
     # structolg < 20.1.0
     # use a "missing" sentinel to avoid a NameError later on
     merge_contextvars = object()
+    clear_contextvars = lambda *a, **kw: None
 
 
 __version__ = "0.6"
@@ -91,6 +94,7 @@ def log(monkeypatch, request):
             # see https://github.com/wimglenn/pytest-structlog/issues/20
             new_processors.append(processor)
     new_processors.append(cap.process)
+    clear_contextvars()
     structlog.configure(processors=new_processors, cache_logger_on_first_use=False)
     cap.original_configure = configure = structlog.configure
     cap.configure_once = structlog.configure_once

--- a/pytest_structlog.py
+++ b/pytest_structlog.py
@@ -7,7 +7,7 @@ try:
     from structlog.contextvars import merge_contextvars
     from structlog.contextvars import clear_contextvars
 except ImportError:
-    # structolg < 20.1.0
+    # structlog < 20.1.0
     # use a "missing" sentinel to avoid a NameError later on
     merge_contextvars = object()
     clear_contextvars = lambda *a, **kw: None
@@ -94,14 +94,15 @@ def log(monkeypatch, request):
             # see https://github.com/wimglenn/pytest-structlog/issues/20
             new_processors.append(processor)
     new_processors.append(cap.process)
-    clear_contextvars()
     structlog.configure(processors=new_processors, cache_logger_on_first_use=False)
     cap.original_configure = configure = structlog.configure
     cap.configure_once = structlog.configure_once
     monkeypatch.setattr("structlog.configure", no_op)
     monkeypatch.setattr("structlog.configure_once", no_op)
     request.node.structlog_events = cap.events
+    clear_contextvars()
     yield cap
+    clear_contextvars()
 
     # back to original behavior
     configure(processors=original_processors)

--- a/pytest_structlog.py
+++ b/pytest_structlog.py
@@ -10,7 +10,7 @@ except ImportError:
     # structlog < 20.1.0
     # use a "missing" sentinel to avoid a NameError later on
     merge_contextvars = object()
-    clear_contextvars = lambda *a, **kw: None
+    clear_contextvars = lambda *a, **kw: None  # noqa
 
 
 __version__ = "0.6"

--- a/tests/test_issue24.py
+++ b/tests/test_issue24.py
@@ -8,7 +8,7 @@ logger = structlog.get_logger()
 
 @pytest.fixture(scope="module")
 def issue24_setup():
-    """Isolate this module's contextvars from other tests, even while issue 20 is present"""
+    """Isolate this module's contextvars from other tests, even while issue 24 is present"""
     pytest.importorskip("structlog.contextvars")
     structlog.contextvars.clear_contextvars()
     yield

--- a/tests/test_issue24.py
+++ b/tests/test_issue24.py
@@ -1,0 +1,34 @@
+import os
+
+import pytest
+import structlog
+
+logger = structlog.get_logger()
+
+
+@pytest.fixture(scope="module")
+def issue24_setup():
+    """Isolate this module's contextvars from other tests, even while issue 20 is present"""
+    pytest.importorskip("structlog.contextvars")
+    structlog.contextvars.clear_contextvars()
+    yield
+    structlog.contextvars.clear_contextvars()
+
+
+# Make sure that at least one process runs the test at least twice
+try:
+    RUN_COUNT = int(os.environ.get("PYTEST_XDIST_WORKER_COUNT", 1)) + 1
+except:
+    RUN_COUNT = 2
+
+
+@pytest.mark.parametrize("n", list(range(RUN_COUNT)))
+def test_contextvar_isolation_in_events(issue24_setup, log, n):
+    logger.info("without_context")
+    structlog.contextvars.bind_contextvars(ctx=n)
+    logger.info("with_context")
+    assert log.events == [
+        {"event": "without_context", "level": "info"},
+        {"event": "with_context", "level": "info", "ctx": n},
+    ]
+    assert structlog.contextvars.get_contextvars() == {"ctx": n}

--- a/tests/test_issue24.py
+++ b/tests/test_issue24.py
@@ -28,7 +28,7 @@ def test_contextvar_isolation_in_events(issue24_setup, log, n):
     structlog.contextvars.bind_contextvars(ctx=n)
     logger.info("with_context")
     assert log.events == [
-        {"event": "without_context", "level": "info"},
+        {"event": "without_context", "level": "info"},  # in issue 24 this has "ctx" from previous run
         {"event": "with_context", "level": "info", "ctx": n},
     ]
     assert structlog.contextvars.get_contextvars() == {"ctx": n}

--- a/tests/test_issue24.py
+++ b/tests/test_issue24.py
@@ -18,7 +18,7 @@ def issue24_setup():
 # Make sure that at least one process runs the test at least twice
 try:
     RUN_COUNT = int(os.environ.get("PYTEST_XDIST_WORKER_COUNT", 1)) + 1
-except:
+except Exception:
     RUN_COUNT = 2
 
 


### PR DESCRIPTION
Closes #24 by clearing contextvars beforeyielding log fixture