### PR TITLE
Add logger-name assertion

### DIFF
--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -39,6 +39,7 @@ def test_assert_without_context(log):
 def test_assert_with_subcontext(log):
     spline_reticulator()
     assert log.has("reticulating splines", n_splines=123)
+    assert log.has("reticulating splines", logger="test")
 
 
 def test_assert_with_bogus_context(log):


### PR DESCRIPTION
I have been unable to make this work in a project where I've installed structlog and pytest-structlog.

Instead of getting a pass, I get an error like:

```console
..F                                                                                                                                                                                                                                                                          [100%]
===================================================================================================================================== FAILURES =====================================================================================================================================
___________________________________________________________________________________________________________________________________ test_plugin ____________________________________________________________________________________________________________________________________

my_log = <common.log.Logger object at 0x10df971d0>, log = <pytest_structlog.StructuredLogCapture object at 0x10dfa70d0>

    def test_plugin(my_log, log):
        assert len(log.events) == 0
        logger = my_log.get_logger('unit-test')
        logger.warning('foo')
        assert len(log.events) == 1
        assert [
            {
                'event': 'foo',
                'log_level': 'warning',
                'logger': 'unit-test',
            }
        ]
>       assert log.has('foo', logger='unit-test')
E       AssertionError: assert False
E        +  where False = <bound method StructuredLogCapture.has of <pytest_structlog.StructuredLogCapture object at 0x10dfa70d0>>('foo', logger='unit-test')
E        +    where <bound method StructuredLogCapture.has of <pytest_structlog.StructuredLogCapture object at 0x10dfa70d0>> = <pytest_structlog.StructuredLogCapture object at 0x10dfa70d0>.has

components/common/test/test_log.py:24: AssertionError
----------------------------------------------------------------------------------------------------------------------------- Captured structlog call ------------------------------------------------------------------------------------------------------------------------------
{'event': 'foo', 'level': 'warning'}
============================================================================================================================= short test summary info ==============================================================================================================================
FAILED components/common/test/test_log.py::test_plugin - AssertionError: assert False
 +  where False = <bound method StructuredLogCapture.has of <pytest_structlog.StructuredLogCapture object at 0x10dfa70d0>>('foo', logger='unit-test')
 +    where <bound method StructuredLogCapture.has of <pytest_structlog.StructuredLogCapture object at 0x10dfa70d0>> = <pytest_structlog.StructuredLogCapture object at 0x10dfa70d0>.has
1 failed, 2 passed in 0.40s
```